### PR TITLE
chore: Update dependencies and tools to latest stable versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion '33.0.1'
+    compileSdk 34
+
 
     defaultConfig {
         applicationId "com.project.ggyucoinproject"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -32,15 +32,16 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {
+        buildConfig true
         dataBinding true
     }
     namespace 'com.project.ggyucoinproject'
@@ -48,9 +49,9 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
@@ -66,8 +67,8 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
-    implementation 'com.github.bumptech.glide:glide:4.15.1'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.15.1'
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
+    kapt 'com.github.bumptech.glide:compiler:4.16.0'
 
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"

--- a/app/src/main/java/com/project/ggyucoinproject/domain/usecase/OwnerUseCase.kt
+++ b/app/src/main/java/com/project/ggyucoinproject/domain/usecase/OwnerUseCase.kt
@@ -1,7 +1,7 @@
 package com.project.ggyucoinproject.domain.usecase
 
 import androidx.lifecycle.MutableLiveData
-import androidx.viewbinding.BuildConfig
+import com.project.ggyucoinproject.BuildConfig
 import com.project.ggyucoinproject.common.MainDatabase
 import com.project.ggyucoinproject.data.entity.MarketEntity
 import com.project.ggyucoinproject.data.model.MarketData

--- a/app/src/main/java/com/project/ggyucoinproject/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/project/ggyucoinproject/presentation/MainViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(private val useCase: OwnerUseCase) : ViewModel() {
 
-    val domainList: LiveData<List<CoinDomain>> = Transformations.map(useCase.domainList) { coins ->
+    val domainList: LiveData<List<CoinDomain>> = useCase.domainList.map { coins ->
         val filter = query.value
         if (filter.isNullOrEmpty()) coins
         else coins.filter { it.market.contains(filter.uppercase(Locale.getDefault())) }
@@ -20,7 +20,7 @@ class MainViewModel @Inject constructor(private val useCase: OwnerUseCase) : Vie
 
     val query = MutableLiveData<String>()
 
-    val bitcoin: LiveData<CoinDomain> = Transformations.map(useCase.domainList) { coins ->
+    val bitcoin: LiveData<CoinDomain?> = useCase.domainList.map { coins ->
         coins.find { it.market == "KRW-BTC" }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.8.20'
-        nav_version = '2.5.3'
-        room_version = "2.5.1"
-        hilt_version = '2.46.1'
+        kotlin_version = '1.9.23'
+        nav_version = '2.7.7'
+        room_version = "2.6.1"
+        hilt_version = '2.51.1'
     }
 
     repositories {
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip


### PR DESCRIPTION
This submission updates the project to modern Android development standards.

It upgrades:
* Gradle Wrapper to 8.7
* Android Gradle Plugin to 8.3.1
* Kotlin to 1.9.23
* Target & Compile SDKs to 34
* Java compatibility to Java 17
* Hilt to 2.51.1, Room to 2.6.1, Navigation to 2.7.7, Glide to 4.16.0

Code adjustments made for the upgrades:
* Replaced deprecated `Transformations.map` with `LiveData.map` in ViewModel.
* Corrected `BuildConfig` references and enabled `buildConfig true` in `app/build.gradle` (since AGP 8.0+ disables it by default).
* Replaced Glide's `annotationProcessor` with `kapt`.

---
*PR created automatically by Jules for task [9283218562004625657](https://jules.google.com/task/9283218562004625657) started by @DevGGyu*