### PR TITLE
⚡ Optimize favorite filtering search complexity

### DIFF
--- a/app/src/main/java/com/project/ggyucoinproject/presentation/favorite/FavoriteFragment.kt
+++ b/app/src/main/java/com/project/ggyucoinproject/presentation/favorite/FavoriteFragment.kt
@@ -44,8 +44,9 @@ class FavoriteFragment : Fragment(), SelectCoinListener {
         viewModel.favorites.observe(viewLifecycleOwner) { favoriteMarkets ->
             sharedViewModel.domainList.observe(viewLifecycleOwner) { domains ->
                 viewLifecycleOwner.lifecycleScope.launch {
+                    val favoriteSet = favoriteMarkets.toSet()
                     val favorites = domains.filter {
-                        favoriteMarkets.contains(it.market)
+                        favoriteSet.contains(it.market)
                     }.toList()
                     adapter.submitList(favorites)
                 }


### PR DESCRIPTION
The filtering logic in `FavoriteFragment` was using a linear search on a list of favorite markets for every coin in the main domain list. This resulted in quadratic complexity in the worst case. By converting the list of favorites to a `Set`, the lookup for each coin is now O(1) on average, making the entire filtering operation O(N+M). Verified with a standalone Java benchmark as the Gradle environment had network/timeout issues.

---
*PR created automatically by Jules for task [6495082496812241289](https://jules.google.com/task/6495082496812241289) started by @DevGGyu*