### PR TITLE
🔒 [security fix] Disable application backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
🎯 **What:** The application had `android:allowBackup` set to `true` in the manifest.
⚠️ **Risk:** This allows unauthorized data extraction from the device via `adb backup`, potentially exposing sensitive user data.
🛡️ **Solution:** Set `android:allowBackup="false"` in `app/src/main/AndroidManifest.xml` to prevent the backup mechanism from extracting app data.

---
*PR created automatically by Jules for task [13633220967096859061](https://jules.google.com/task/13633220967096859061) started by @DevGGyu*